### PR TITLE
Improve shortcode handling with inline JS and shortcake support

### DIFF
--- a/src/Twitter/WordPress/PluginLoader.php
+++ b/src/Twitter/WordPress/PluginLoader.php
@@ -78,10 +78,12 @@ class PluginLoader
 			add_action( 'init', array( __CLASS__, 'adminInit' ) );
 		} else {
 			// hooks to be executed on general execution of WordPress such as public pageviews
-			static::registerShortcodeHandlers();
 			add_action( 'init', array( __CLASS__, 'publicInit' ) );
 			add_action( 'wp_head', array( __CLASS__, 'wpHead' ), 1, 0 );
 		}
+
+		// shortcodes
+		static::registerShortcodeHandlers();
 	}
 
 	/**

--- a/src/Twitter/WordPress/Shortcodes/EmbeddedTweetVideo.php
+++ b/src/Twitter/WordPress/Shortcodes/EmbeddedTweetVideo.php
@@ -62,6 +62,55 @@ class EmbeddedTweetVideo extends EmbeddedTweet
 	{
 		// register our shortcode and its handler
 		add_shortcode( self::SHORTCODE_TAG, array( __CLASS__, 'shortcodeHandler' ) );
+
+		// Shortcake UI
+		if ( function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+			add_action(
+				'admin_init',
+				array( __CLASS__, 'shortcodeUI' ),
+				5,
+				0
+			);
+		}
+	}
+
+	/**
+	 * Describe shortcode for Shortcake UI
+	 *
+	 * @since 1.1.0
+	 *
+	 * @link https://github.com/fusioneng/Shortcake Shortcake UI
+	 *
+	 * @return void
+	 */
+	public static function shortcodeUI()
+	{
+		// Shortcake required
+		if ( ! function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+			return;
+		}
+
+		// id only
+		// avoids an unchecked Shortcake input checkbox requiring a shortcode output
+		shortcode_ui_register_for_shortcode(
+			self::SHORTCODE_TAG,
+			array(
+				'label'         => __( 'Embedded Tweet Video', 'twitter' ),
+				'listItemImage' => 'dashicons-twitter',
+				'attrs'         => array(
+					array(
+						'attr'  => 'id',
+						'label' => 'ID',
+						'type'  => 'text',
+						'meta'  => array(
+							'required'    => true,
+							'pattern'     => '[0-9]+',
+							'placeholder' => '560070183650213889',
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -152,8 +201,14 @@ class EmbeddedTweetVideo extends EmbeddedTweet
 			return '';
 		}
 
-		\Twitter\WordPress\JavaScriptLoaders\Widgets::enqueue();
-		return '<div class="twitter-video">' . $html . '</div>';
+		$html = '<div class="twitter-video">' . $html . '</div>';
+
+		$inline_js = \Twitter\WordPress\JavaScriptLoaders\Widgets::enqueue();
+		if ( $inline_js ) {
+			return $html . $inline_js;
+		}
+
+		return $html;
 	}
 
 	/**

--- a/src/Twitter/WordPress/Shortcodes/Follow.php
+++ b/src/Twitter/WordPress/Shortcodes/Follow.php
@@ -61,6 +61,62 @@ class Follow
 	public static function init()
 	{
 		add_shortcode( static::SHORTCODE_TAG, array( __CLASS__, 'shortcodeHandler' ) );
+
+		// Shortcake UI
+		if ( function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+			add_action(
+				'admin_init',
+				array( __CLASS__, 'shortcodeUI' ),
+				5,
+				0
+			);
+		}
+	}
+
+	/**
+	 * Describe shortcode for Shortcake UI
+	 *
+	 * @since 1.1.0
+	 *
+	 * @link https://github.com/fusioneng/Shortcake Shortcake UI
+	 *
+	 * @return void
+	 */
+	public static function shortcodeUI()
+	{
+		// Shortcake required
+		if ( ! function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+			return;
+		}
+
+		shortcode_ui_register_for_shortcode(
+			static::SHORTCODE_TAG,
+			array(
+				'label'         => __( 'Follow Button', 'twitter' ),
+				'listItemImage' => 'dashicons-twitter',
+				'attrs'         => array(
+					array(
+						'attr'  => 'screen_name',
+						'label' => __( 'Twitter @username', 'twitter' ),
+						'type'  => 'text',
+						'meta'  => array(
+							'placeholder' => 'WordPress',
+							'pattern'     => '[A-Za-z0-9_]{1,20}',
+						),
+					),
+					array(
+						'attr'    => 'size',
+						'label'   => __( 'Button size:', 'twitter' ),
+						'type'    => 'radio',
+						'value'   => 'medium',
+						'options' => array(
+							''      => _x( 'medium', 'medium size button', 'twitter' ),
+							'large' => _x( 'large',  'large size button',  'twitter' ),
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -187,7 +243,13 @@ class Follow
 			return '';
 		}
 
-		\Twitter\WordPress\JavaScriptLoaders\Widgets::enqueue();
-		return '<div class="twitter-follow">' . $html . '</div>';
+		$html = '<div class="twitter-follow">' . $html . '</div>';
+
+		$inline_js = \Twitter\WordPress\JavaScriptLoaders\Widgets::enqueue();
+		if ( $inline_js ) {
+			return $html . $inline_js;
+		}
+
+		return $html;
 	}
 }

--- a/src/Twitter/WordPress/Shortcodes/Share.php
+++ b/src/Twitter/WordPress/Shortcodes/Share.php
@@ -61,6 +61,63 @@ class Share
 	public static function init()
 	{
 		add_shortcode( static::SHORTCODE_TAG, array( __CLASS__, 'shortcodeHandler' ) );
+
+		// Shortcake UI
+		if ( function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+			add_action(
+				'admin_init',
+				array( __CLASS__, 'shortcodeUI' ),
+				5,
+				0
+			);
+		}
+	}
+
+	/**
+	 * Describe shortcode for Shortcake UI
+	 *
+	 * @since 1.1.0
+	 *
+	 * @link https://github.com/fusioneng/Shortcake Shortcake UI
+	 *
+	 * @return void
+	 */
+	public static function shortcodeUI()
+	{
+		// Shortcake required
+		if ( ! function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+			return;
+		}
+
+		shortcode_ui_register_for_shortcode(
+			static::SHORTCODE_TAG,
+			array(
+				'label'         => __( 'Tweet Button', 'twitter' ),
+				'listItemImage' => 'dashicons-twitter',
+				'attrs'         => array(
+					array(
+						'attr'  => 'text',
+						'label' => _x( 'Text', 'Share / Tweet text', 'twitter' ),
+						'type'  => 'text',
+					),
+					array(
+						'attr'    => 'url',
+						'label'   => 'URL',
+						'type'    => 'url',
+					),
+					array(
+						'attr'    => 'size',
+						'label'   => __( 'Button size:', 'twitter' ),
+						'type'    => 'radio',
+						'value'   => 'medium',
+						'options' => array(
+							''      => _x( 'medium', 'medium size button', 'twitter' ),
+							'large' => _x( 'large',  'large size button',  'twitter' ),
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -374,7 +431,13 @@ class Share
 			return '';
 		}
 
-		\Twitter\WordPress\JavaScriptLoaders\Widgets::enqueue();
-		return '<div class="twitter-share">' . $html . '</div>';
+		$html = '<div class="twitter-share">' . $html . '</div>';
+
+		$inline_js = \Twitter\WordPress\JavaScriptLoaders\Widgets::enqueue();
+		if ( $inline_js ) {
+			return $html . $inline_js;
+		}
+
+		return $html;
 	}
 }

--- a/src/Twitter/WordPress/Shortcodes/Tracking.php
+++ b/src/Twitter/WordPress/Shortcodes/Tracking.php
@@ -70,6 +70,52 @@ class Tracking
 	public static function init()
 	{
 		add_shortcode( static::SHORTCODE_TAG, array( __CLASS__, 'shortcodeHandler' ) );
+
+		// Shortcake UI
+		if ( function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+			add_action(
+				'admin_init',
+				array( __CLASS__, 'shortcodeUI' ),
+				5,
+				0
+			);
+		}
+	}
+
+	/**
+	 * Describe shortcode for Shortcake UI
+	 *
+	 * @since 1.1.0
+	 *
+	 * @link https://github.com/fusioneng/Shortcake Shortcake UI
+	 *
+	 * @return void
+	 */
+	public static function shortcodeUI()
+	{
+		// Shortcake required
+		if ( ! function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+			return;
+		}
+
+		shortcode_ui_register_for_shortcode(
+			static::SHORTCODE_TAG,
+			array(
+				'label'         => __( 'Twitter Advertising Tracker', 'twitter' ),
+				'listItemImage' => 'dashicons-twitter',
+				'attrs'         => array(
+					array(
+						'attr'  => 'id',
+						'label' => 'ID',
+						'description' => __( 'Twitter conversion or remarketing audience tracking identifier', 'twitter' ),
+						'type'  => 'text',
+						'meta'  => array(
+							'required' => true,
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Inline JavaScript

Include an [asynchronously loaded JavaScript snippet](https://dev.twitter.com/web/javascript/loading "Twitter widgets JavaScript loading snippet documentation") if shortcode markup is generated while `DOING_AJAX`.

Plugin shortcodes enqueue Twitter's widgets JavaScript when included in a page. It's possible enqueued JavaScript will never be output to the page during a standard execution such as during the `wp_footer` action. Treat the `DOING_AJAX` named constant as an indicator enqueued JavaScript will not be output. Return inline JavaScript loader instead.

The inline JavaScript loader uses the same DOM ID as the registered script handle, exiting early if a DOM element with an ID matching the registered handle is found.

## Shortcake UI

Register a shortcode and its attributes with [Shortcake UI](https://github.com/fusioneng/Shortcake "Shortcake UI WordPress plugin GitHub repository") if Shortcake handlers are present. Shortcake displays form-based shortcode constructors in the WordPress administrative interface's post editor's Add Media modal.

## Always register shortcodes

Shortcodes are now registered for use in administrative views. Shortcodes should be available for post previews and other admin-specific views.