### PR TITLE
add an embedded search widget via shortcode or widget

### DIFF
--- a/src/Twitter/Helpers/HTMLBuilder.php
+++ b/src/Twitter/Helpers/HTMLBuilder.php
@@ -146,7 +146,7 @@ class HTMLBuilder
                 // filter and store
                 if (! empty($attribute_tokens)) {
                     $attribute_tokens = array_map(
-                        __CLASS__ . '::' . ( $attribute === 'class' ? 'escapeClassName' : 'escapeAttribute' ),
+                        get_called_class() . '::' . ( $attribute === 'class' ? 'escapeClassName' : 'escapeAttribute' ),
                         $attribute_tokens
                     );
                     if (! empty($attribute_tokens)) {
@@ -184,6 +184,9 @@ class HTMLBuilder
             foreach ($data_attributes as $attribute => $value) {
                 if (! $attribute) {
                     continue;
+                }
+                if (is_array($value)) {
+                    $value = implode(' ', $value);
                 }
 
                 $clean_attributes[ 'data-' . $attribute ] = static::escapeAttributeValue(trim($value));

--- a/src/Twitter/Widgets/Embeds/Timeline/Search.php
+++ b/src/Twitter/Widgets/Embeds/Timeline/Search.php
@@ -1,0 +1,313 @@
+<?php
+/*
+The MIT License (MIT)
+
+Copyright (c) 2017 Twitter Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+namespace Twitter\Widgets\Embeds\Timeline;
+
+/**
+ * Display Tweets published within the last ~7 days for a given widget ID
+ *
+ * @since 2.0.0
+ */
+class Search extends \Twitter\Widgets\Embeds\Timeline
+{
+    /**
+     * HTML class expected by the Twitter widget JS
+     *
+     * @since 2.0.0
+     *
+     * @type string
+     */
+    const HTML_CLASS = 'twitter-timeline';
+
+    /**
+     * Construct a full Twitter URI by appending to base string
+     *
+     * @since 2.0.0
+     *
+     * @type string
+     */
+    const BASE_URL = 'https://twitter.com/search';
+
+    /**
+     * Widget ID configured on Twitter.com
+     *
+     * @since 2.0.0
+     *
+     * @see https://twitter.com/settings/widgets/new/search Search widget configuration
+     *
+     * @type string
+     */
+    protected $widget_id;
+
+    /**
+     * Search terms set in the widget ID
+     *
+     * Used to construct a meaningful link to a search results page and relevant link text.
+     *
+     * @since 2.0.0
+     *
+     * @type string
+     */
+    protected $search_terms;
+
+    /**
+     * Create a new search timeline widget with a required widget ID and optional search terms
+     *
+     * @since 2.0.0
+     *
+     * @param string $widget_id widget identifier
+     * @param string $search_terms (optional) search terms for display in link
+     */
+    public function __construct($widget_id, $search_terms = '')
+    {
+        $this->setWidgetID($widget_id);
+        if ($search_terms) {
+            $this->setSearchTerms($search_terms);
+        }
+    }
+
+    /**
+     * Test widget ID validity
+     *
+     * @since 2.0.0
+     *
+     * @param string $id widget ID
+     *
+     * @return bool true if valid widget ID
+     */
+    public static function isValidWidgetID($id)
+    {
+        if (is_string($id)) {
+            if (function_exists('ctype_digit')) {
+                return ctype_digit($id);
+            } else {
+                return (bool) (preg_match("/^[0-9]+$/", $id));
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get a widget ID corresponding to a saved search
+     *
+     * @since 2.0.0
+     *
+     * @return string widget ID if set else empty string
+     */
+    public function getWidgetID()
+    {
+        return $this->widget_id ?: '';
+    }
+
+    /**
+     * Set a widget ID corresponding to a saved search
+     *
+     * @since 2.0.0
+     *
+     * @param string $widget_id widget identifier
+     *
+     * @return self support chaining
+     */
+    public function setWidgetID($widget_id)
+    {
+        if (is_string($widget_id)) {
+            $widget_id = trim($widget_id);
+            if (static::isValidWidgetID($widget_id)) {
+                $this->widget_id = $widget_id;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get search terms for more meaningful fallback display
+     *
+     * Should match the search terms stored for the widget ID. Does not affect rendered widget
+     *
+     * @since 2.0.0
+     *
+     * @return string search terms or empty string if no search terms set
+     */
+    public function getSearchTerms()
+    {
+        return $this->search_terms ?: '';
+    }
+
+    /**
+     * Set search terms used by markup builder for more meaningful fallback display
+     *
+     * Should match search terms stored for the widget ID. Does not affect rendered widget.
+     *
+     * @since 2.0.0
+     *
+     * @param string $terms search terms
+     *
+     * @return self support chaining
+     */
+    public function setSearchTerms($terms)
+    {
+        if (is_string($terms)) {
+            $terms = trim($terms);
+            if ($terms) {
+                $this->search_terms = $terms;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Build a URL to a Twitter search page, with terms if set
+     *
+     * @since 2.0.0
+     *
+     * @return string Twitter search URL
+     */
+    public function getURL()
+    {
+        $url = static::BASE_URL;
+        $search_terms = $this->getSearchTerms();
+        if ($search_terms) {
+            $url .= '?' . http_build_query(
+                array( 'q' => $search_terms ),
+                '',
+                '&',
+                PHP_QUERY_RFC3986
+            );
+        }
+
+        return $url;
+    }
+
+    /**
+     * Create a search timeline object from an associative array
+     *
+     * @since 2.0.0
+     *
+     * @param array $options {
+     *   @type string          parameter name
+     *   @type string|int|bool parameter value
+     * }
+     *
+     * @return self|null new Search object with configured properties or null if minimum requirements not met
+     */
+    public static function fromArray($options)
+    {
+        // widget ID required
+        if (! (is_array($options) && isset($options['widget_id']))) {
+            return null;
+        }
+
+        if (! (is_string($options['widget_id']) && $options['widget_id'])) {
+            return null;
+        }
+
+        $search_terms = '';
+        if (isset($options['terms']) && is_string($options['terms']) && $options['terms']) {
+            $search_terms = $options['terms'];
+        }
+
+        $class = get_called_class();
+        $timeline = new $class( $options['widget_id'], $search_terms );
+
+        if (method_exists($timeline, 'setBaseOptions')) {
+            $timeline->setBaseOptions($options);
+        }
+
+        return $timeline;
+    }
+
+    /**
+     * Convert the class object into an array, removing default field values
+     *
+     * @since 2.0.0
+     *
+     * @return array properties as associative array
+     */
+    public function toArray()
+    {
+        $data = parent::toArray();
+
+        if ($this->widget_id) {
+            $data['widget-id'] = $this->widget_id;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Disabled. oEmbed is not supported for a search timeline widget
+     *
+     * @since 2.0.0
+     *
+     * @return array empty array
+     */
+    public function toOEmbedParameterArray()
+    {
+        // not supported
+        return array();
+    }
+
+    /**
+     * Generate HTML as fallback markup for the Twitter for Websites JavaScript
+     *
+     * @since 2.0.0
+     *
+     * @param string $anchor_text inner text of the generated anchor element. Supports a single '%s' screen name passed through sprintf. Default: Follow %s
+     * @param string $html_builder_class callable HTML builder with a static anchorElement class
+     *
+     * @return string HTML markup or empty string if minimum requirements not met
+     */
+    public function toHTML($anchor_text = 'Tweets about %s', $html_builder_class = '\Twitter\Helpers\HTMLBuilder')
+    {
+        if (! ( is_string($anchor_text) && $anchor_text )) {
+            return '';
+        }
+
+        // test for invalid passed class
+        if (! ( class_exists($html_builder_class) && method_exists($html_builder_class, 'anchorElement') )) {
+            return '';
+        }
+
+        $search_url = $this->getURL();
+        $search_terms = $this->getSearchTerms();
+        if ($search_terms) {
+            $anchor_text = sprintf($anchor_text, $search_terms);
+        } else {
+            $anchor_text = 'Twitter Search';
+        }
+
+        return $html_builder_class::anchorElement(
+            $search_url,
+            $anchor_text,
+            array(
+                'class' => static::HTML_CLASS,
+            ),
+            $this->toArray()
+        );
+    }
+}

--- a/src/Twitter/WordPress/Features.php
+++ b/src/Twitter/WordPress/Features.php
@@ -101,6 +101,17 @@ class Features
 	const EMBED_LIST = 'embed-list';
 
 	/**
+	 * Embed recent Tweets matching a search query configured at twitter.com/settings/widgets
+	 *
+	 * @since 2.0.0
+	 *
+	 * @link https://dev.twitter.com/web/embedded-timelines/search Embedded Search Timeline
+	 *
+	 * @type string
+	 */
+	const EMBED_SEARCH = 'embed-search';
+
+	/**
 	 * Embed multiple Tweets in a vertical format by URL or shortcode
 	 *
 	 * @since 2.0.0
@@ -197,6 +208,7 @@ class Features
 		self::EMBED_VINE            => true, // single Vine
 		self::EMBED_PROFILE         => true, // Twitter profile
 		self::EMBED_LIST            => true, // Twitter List
+		self::EMBED_SEARCH          => true, // Twitter search
 		self::EMBED_COLLECTION      => true, // multiple Tweets organized into a collection
 		self::EMBED_COLLECTION_GRID => true, // multiple Tweets organized into a collection displayed in a grid format
 		self::EMBED_MOMENT          => true, // Twitter Moment

--- a/src/Twitter/WordPress/PluginLoader.php
+++ b/src/Twitter/WordPress/PluginLoader.php
@@ -141,6 +141,7 @@ class PluginLoader
 			\Twitter\WordPress\Features::PERISCOPE_ON_AIR => '\Twitter\WordPress\Widgets\Buttons\Periscope\OnAir',
 			\Twitter\WordPress\Features::EMBED_PROFILE    => '\Twitter\WordPress\Widgets\Embeds\Timeline\Profile',
 			\Twitter\WordPress\Features::EMBED_LIST       => '\Twitter\WordPress\Widgets\Embeds\Timeline\TwitterList',
+			\Twitter\WordPress\Features::EMBED_SEARCH     => '\Twitter\WordPress\Widgets\Embeds\Timeline\Search',
 			\Twitter\WordPress\Features::EMBED_COLLECTION => '\Twitter\WordPress\Widgets\Embeds\Timeline\Collection',
 			\Twitter\WordPress\Features::TRACKING_PIXEL   => '\Twitter\WordPress\Widgets\Advertising\Tracking',
 		);
@@ -284,12 +285,13 @@ class PluginLoader
 			}
 		}
 
-		// initialize buttons and ad pixel if not disabled
+		// initialize buttons, search timeline, and ad pixel if not disabled
 		foreach (
 			array(
 				\Twitter\WordPress\Features::FOLLOW_BUTTON    => 'Buttons\\Follow',
 				\Twitter\WordPress\Features::TWEET_BUTTON     => 'Buttons\\Share',
-				\Twitter\WordPress\Features::PERISCOPE_ON_AIR => 'Buttons\\Periscope\OnAir',
+				\Twitter\WordPress\Features::PERISCOPE_ON_AIR => 'Buttons\\Periscope\\OnAir',
+				\Twitter\WordPress\Features::EMBED_SEARCH     => 'Embeds\\Timeline\\Search',
 				\Twitter\WordPress\Features::TRACKING_PIXEL   => 'Advertising\\Tracking',
 			) as $feature => $shortcode_class
 		) {

--- a/src/Twitter/WordPress/Shortcodes/Buttons/Follow.php
+++ b/src/Twitter/WordPress/Shortcodes/Buttons/Follow.php
@@ -124,7 +124,7 @@ class Follow implements \Twitter\WordPress\Shortcodes\ShortcodeInterface
 						'type'  => 'text',
 						'meta'  => array(
 							'placeholder' => 'WordPress',
-							'pattern'     => '[A-Za-z0-9_]{1,20}',
+							'pattern'     => \Twitter\Helpers\Validators\ScreenName::getPattern(),
 						),
 					),
 					array(

--- a/src/Twitter/WordPress/Shortcodes/Embeds/Timeline/Search.php
+++ b/src/Twitter/WordPress/Shortcodes/Embeds/Timeline/Search.php
@@ -1,0 +1,228 @@
+<?php
+/*
+The MIT License (MIT)
+
+Copyright (c) 2017 Twitter Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+namespace Twitter\WordPress\Shortcodes\Embeds\Timeline;
+
+/**
+ * Display recent search results in a timeline
+ *
+ * @since 2.0.0
+ */
+class Search implements \Twitter\WordPress\Shortcodes\ShortcodeInterface
+{
+	use \Twitter\WordPress\Shortcodes\Embeds\Timeline;
+
+	/**
+	 * Shortcode tag to be matched
+	 *
+	 * @since 2.0.0
+	 *
+	 * @type string
+	 */
+	const SHORTCODE_TAG = 'twitter_search';
+
+	/**
+	 * HTML class to be used in div wrapper
+	 *
+	 * @since 2.0.0
+	 *
+	 * @type string
+	 */
+	const HTML_CLASS = 'twitter-timeline-search';
+
+	/**
+	 * Accepted shortcode attributes and their default values
+	 *
+	 * @since 2.0.0
+	 *
+	 * @type array
+	 */
+	public static $SHORTCODE_DEFAULTS = array( 'widget_id' => '', 'terms' => '' );
+
+	/**
+	 * Reference the feature by name
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return string translated feature name
+	 */
+	public static function featureName()
+	{
+		return _x( 'Twitter Search', 'Tweets matching a search result query', 'twitter' );
+	}
+
+	/**
+	 * Attach handlers for shortcode, shortcode UI
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return void
+	 */
+	public static function init()
+	{
+		$classname = get_called_class();
+
+		// register our shortcode and its handler
+		add_shortcode( static::SHORTCODE_TAG, array( $classname, 'shortcodeHandler' ) );
+
+		// Shortcode UI, if supported
+		add_action(
+			'register_shortcode_ui',
+			array( $classname, 'shortcodeUI' ),
+			5,
+			0
+		);
+	}
+
+	/**
+	 * Describe shortcode for Shortcake UI
+	 *
+	 * @since 2.0.0
+	 *
+	 * @link https://github.com/wp-shortcake/shortcake Shortcode UI
+	 *
+	 * @return void
+	 */
+	public static function shortcodeUI()
+	{
+		// Shortcake required
+		if ( ! function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+			return;
+		}
+
+		shortcode_ui_register_for_shortcode(
+			static::SHORTCODE_TAG,
+			array(
+				'label'         => esc_html( static::featureName() ),
+				'listItemImage' => 'dashicons-twitter',
+				'attrs'         => array(
+					array(
+						'attr'  => 'widget_id',
+						'label' => esc_html( __( 'Widget ID', 'twitter' ) ),
+						'type'  => 'text',
+						'meta'  => array(
+							'pattern'     => '[0-9]+',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Handle shortcode macro
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array  $attributes set of shortcode attribute-value pairs or positional content matching the WordPress shortcode regex {
+	 *   @type string|int attribute name or positional int
+	 *   @type mixed      shortcode value
+	 * }
+	 * @param string $content    content inside a shortcode macro. no effect on this shortcode
+	 *
+	 * @return string HTML markup. empty string if parameter requirement not met or no profile info found
+	 */
+	public static function shortcodeHandler( $attributes, $content = '' )
+	{
+		$options = static::getShortcodeAttributes( $attributes );
+		if ( isset( $options['widget_id'] ) ) {
+			$options['widget_id'] = trim( $options['widget_id'] );
+		} else {
+			return '';
+		}
+
+		$timeline = \Twitter\Widgets\Embeds\Timeline\Search::fromArray( $options );
+		if ( ! ( $timeline && $timeline->getWidgetID() ) ) {
+			return '';
+		}
+
+		return static::getHTMLForTimeline( $timeline );
+	}
+
+	/**
+	 * Get HTML markup for a timeline
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param \Twitter\Widgets\Embeds\Timeline\Search $timeline timeline object
+	 *
+	 * @return string HTML markup or empty string if minimum requirements not met
+	 */
+	public static function getHTMLForTimeline( $timeline )
+	{
+		// verify passed parameter
+		if ( ! is_a( $timeline, '\Twitter\Widgets\Embeds\Timeline\Search' ) ) {
+			return '';
+		}
+
+		if ( $timeline->getSearchTerms() ) {
+			$link_text = _x( 'Tweets about %s', 'Tweets about a term or topic', 'twitter' );
+		} else {
+			$link_text = static::featureName();
+		}
+
+		$html = $timeline->toHTML( $link_text, '\Twitter\WordPress\Helpers\HTMLBuilder' );
+		if ( ! $html ) {
+			return '';
+		}
+		$html = '<div class="' . sanitize_html_class( static::HTML_CLASS ) . '">' . $html . '</div>';
+
+		$inline_js = \Twitter\WordPress\JavaScriptLoaders\Widgets::enqueue();
+		if ( $inline_js ) {
+			return $html . $inline_js;
+		}
+
+		return $html;
+	}
+
+	/**
+	 * oEmbed not supported for search timeline
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $query_parameters not used
+	 *
+	 * @return string empty string
+	 */
+	public static function getOEmbedCacheKeyCustomParameters( array $query_parameters )
+	{
+		return '';
+	}
+
+	/**
+	 * oEmbed not supported for search timeline
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $id               not used
+	 * @param array  $query_parameters not used
+	 *
+	 * @return string empty string
+	 */
+	public static function getOEmbedCacheKey( $id, array $query_parameters )
+	{
+		return '';
+	}
+}

--- a/src/Twitter/WordPress/Widgets/Embeds/Timeline/Search.php
+++ b/src/Twitter/WordPress/Widgets/Embeds/Timeline/Search.php
@@ -1,0 +1,135 @@
+<?php
+/*
+The MIT License (MIT)
+
+Copyright (c) 2017 Twitter Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+namespace Twitter\WordPress\Widgets\Embeds\Timeline;
+
+/**
+ * Add embedded search timeline as a WordPress widget
+ *
+ * @see http://codex.wordpress.org/Widgets_API WordPress widgets API
+ *
+ * @since 2.0.0
+ */
+class Search extends \Twitter\WordPress\Widgets\Embeds\Timeline
+{
+	/**
+	 * Class of the related PHP object builder and validator
+	 *
+	 * @since 2.0.0
+	 *
+	 * @type string
+	 */
+	const TIMELINE_CLASS = '\Twitter\Widgets\Embeds\Timeline\Search';
+
+	/**
+	 * Class of the related shortcode handler
+	 *
+	 * @since 2.0.0
+	 *
+	 * @type string
+	 */
+	const SHORTCODE_CLASS = '\Twitter\WordPress\Shortcodes\Embeds\Timeline\Search';
+
+	/**
+	 * Describe the functionality offered by the widget
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return string description of the widget functionality
+	 */
+	public static function getDescription()
+	{
+		return __( 'Recent Tweets matching a Twitter search', 'twitter' );
+	}
+
+	/**
+	 * Fields specific to the timeline datasource configured in the widget
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $instance widget instance
+	 *
+	 * @return void
+	 */
+	protected function dataSourceFormElements( $instance )
+	{
+		?><p><label for="<?php echo esc_attr( $this->get_field_id( 'widget_id' ) ); ?>"><?php echo esc_html( __( 'Twitter widget ID', 'twitter' ) . ':' ); ?></label>
+		<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'widget_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'widget_id' ) ); ?>" type="text" pattern="[0-9]+" inputmode="verbatim" spellcheck="false" value="<?php echo esc_attr( $instance['widget_id'] ); ?>"<?php
+			// @codingStandardsIgnoreLine WordPress.XSS.EscapeOutput.OutputNotEscaped
+			echo \Twitter\WordPress\Helpers\HTMLBuilder::closeVoidHTMLElement();
+		?>><br><small><?php
+			printf(
+				esc_html( _x( 'Create a new widget ID at %s', 'Create a widget identifier at a URL', 'twitter' ) ),
+				'<a href="' . esc_url( 'https://twitter.com/settings/widgets/new/search', array( 'https', 'http' ) )  . '">' . esc_html( 'twitter.com/settings/widgets' ) . '</a>'
+			);
+		?></small></p><p><label for="<?php echo esc_attr( $this->get_field_id( 'terms' ) ); ?>"><?php echo esc_html( __( 'Search terms', 'twitter' ) . ':' ); ?></label><input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'terms' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'terms' ) ); ?>" type="text" maxlength="450" value="<?php echo esc_attr( $instance['terms'] ); ?>"<?php
+			// @codingStandardsIgnoreLine WordPress.XSS.EscapeOutput.OutputNotEscaped
+			echo \Twitter\WordPress\Helpers\HTMLBuilder::closeVoidHTMLElement();
+		?>></p>
+		<?php
+	}
+
+	/**
+	 * Update a widget instance
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $new_instance New settings for this instance as input by the user via form()
+	 * @param array $old_instance Old settings for this instance
+	 *
+	 * @return bool|array settings to save or false to cancel saving
+	 */
+	public function update( $new_instance, $old_instance )
+	{
+		$instance = array();
+		$new_instance = (array) $new_instance;
+		$title = sanitize_text_field( $new_instance['title'] );
+		if ( $title ) {
+			$instance['title'] = $title;
+		}
+		unset( $new_instance['title'] );
+
+		// process widget parameters as if they were parsed shortcode attributes
+		$shortcode_class = static::SHORTCODE_CLASS;
+		$timeline_class  = static::TIMELINE_CLASS;
+		if ( ! ( method_exists( $timeline_class, 'fromArray' ) && method_exists( $shortcode_class, 'shortcodeAttributesToTimelineKeys' ) ) ) {
+			return false;
+		}
+		$timeline = $timeline_class::fromArray( $shortcode_class::shortcodeAttributesToTimelineKeys( $new_instance ) );
+		if ( ! ($timeline && $timeline->getWidgetID() && method_exists( $timeline, 'toArray' ) ) ) {
+			return false;
+		}
+
+		$data_attributes = $timeline->toArray();
+		// convert data-* dashes to shortcode underscores
+		if ( isset( $data_attributes['widget-id'] ) ) {
+			$data_attributes['widget_id'] = $data_attributes['widget-id'];
+			unset( $data_attributes['widget-id'] );
+		}
+		$data_attributes['terms'] = $timeline->getSearchTerms();
+
+		return array_merge( $instance, $data_attributes );
+	}
+}

--- a/tests/phpunit/Widgets/Embeds/Timeline/Search.php
+++ b/tests/phpunit/Widgets/Embeds/Timeline/Search.php
@@ -1,0 +1,273 @@
+<?php
+/*
+The MIT License (MIT)
+
+Copyright (c) 2017 Twitter Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+namespace Twitter\Tests\Widgets\Embeds\Timeline;
+
+/**
+ * @coversDefaultClass \Twitter\Widgets\Embeds\Timeline\Search
+ */
+final class Search extends \Twitter\Tests\TestWithPrivateAccess
+{
+    /**
+     * Widget ID for testing
+     *
+     * @since 2.0.0
+     *
+     * @type string
+     */
+    const VALID_WIDGET_ID = '600756918018179072';
+
+    /**
+     * Test expected use of the constructor
+     *
+     * @since 2.0.0
+     *
+     * @covers ::__construct
+     *
+     * @return void
+     */
+    public function testConstructor()
+    {
+        $classname = '\Twitter\Widgets\Embeds\Timeline\Search';
+        $mock = $this->getMockBuilder($classname)->disableOriginalConstructor()->getMock();
+
+        // set expectations for the constructor call
+        $mock->expects($this->once())
+          ->method('setWidgetID')
+          ->with(
+              $this->equalTo(self::VALID_WIDGET_ID)
+          );
+
+        $reflected_class = new \ReflectionClass($classname);
+        $constructor = $reflected_class->getConstructor();
+        $constructor->invoke($mock, self::VALID_WIDGET_ID);
+    }
+
+    /**
+     * Test constructor with optional search terms parameter included
+     *
+     * @since 2.0.0
+     *
+     * @covers ::__construct
+     *
+     * @return void
+     */
+    public function testConstructorWithSearchTerms()
+    {
+        $classname = '\Twitter\Widgets\Embeds\Timeline\Search';
+        $mock = $this->getMockBuilder($classname)->disableOriginalConstructor()->getMock();
+
+        // set expectations for the optional search terms component of the constructor call
+        $search_terms = 'foo bar';
+        $mock->expects($this->once())
+          ->method('setSearchTerms')
+          ->with(
+              $this->equalTo($search_terms)
+          );
+
+        $reflected_class = new \ReflectionClass($classname);
+        $constructor = $reflected_class->getConstructor();
+        $constructor->invoke($mock, self::VALID_WIDGET_ID, $search_terms);
+    }
+
+    /**
+     * Test verifying a widget ID
+     *
+     * @since 2.0.0
+     *
+     * @dataProvider idProvider
+     *
+     * @covers ::isValidWidgetID
+     *
+     * @param string $id                Twitter widget id
+     * @param bool   $expected_validity expected validity
+     * @param string $message           error message to display
+     *
+     * @return void
+     */
+    public function testIsValidWidgetID($id, $expected_validity, $message = '')
+    {
+        $result = \Twitter\Widgets\Embeds\Timeline\Search::isValidWidgetID($id);
+
+        if ($expected_validity) {
+            $this->assertTrue($result, $message);
+        } else {
+            $this->assertFalse($result, $message);
+        }
+    }
+
+    /**
+     * Provide Twitter widget identifiers for testing
+     *
+     * @since 2.0.0
+     *
+     * @param array {
+     *   @param array test cases
+     * }
+     */
+    public static function idProvider()
+    {
+        return array(
+            array(self::VALID_WIDGET_ID, true,  'Failed to accept a valid widget ID' ),
+            array('twitter',             false, 'Failed to reject a non-numeric ID'  ),
+        );
+    }
+
+    /**
+     * Test setting a widget identifier
+     *
+     * @since 2.0.0
+     *
+     * @depends testIsValidWidgetID
+     * @covers ::setWidgetID
+     *
+     * @return void
+     */
+    public function testSetWidgetID()
+    {
+        $id = '1234';
+        $timeline = new \Twitter\Widgets\Embeds\Timeline\Search($id);
+        $timeline->setWidgetID('twitter');
+        $this->assertEquals($id, self::getProperty($timeline, 'widget_id'), 'Set an ID from an invalid value');
+
+        $timeline->setWidgetID(self::VALID_WIDGET_ID);
+        $this->assertEquals(self::VALID_WIDGET_ID, self::getProperty($timeline, 'widget_id'), 'Failed to set a valid widget ID');
+    }
+
+    /**
+     * Test getting a widget identifier
+     *
+     * @since 2.0.0
+     *
+     * @covers ::getWidgetID
+     *
+     * @return void
+     */
+    public function testGetWidgetID()
+    {
+        $timeline = new \Twitter\Widgets\Embeds\Timeline\Search('');
+        $this->assertEquals('', $timeline->getWidgetID(), 'Failed to return an empty string for expected null ID value');
+
+        self::setProperty($timeline, 'widget_id', self::VALID_WIDGET_ID);
+        $this->assertEquals(self::VALID_WIDGET_ID, $timeline->getWidgetID(), 'Failed to return set ID class variable');
+    }
+
+    /**
+     * Test setting search terms via setter
+     *
+     * @since 2.0.0
+     *
+     * @covers ::setSearchTerms
+     *
+     * @return void
+     */
+    public function testSetSearchTerms()
+    {
+        $timeline = new \Twitter\Widgets\Embeds\Timeline\Search('');
+        $timeline->setSearchTerms('');
+        $this->assertNull(self::getProperty($timeline, 'search_terms'), 'Failed to reject empty search terms');
+
+        $search_terms = 'foo bar';
+        $timeline->setSearchTerms($search_terms);
+        $this->assertEquals($search_terms, self::getProperty($timeline, 'search_terms'), 'Failed to set valid search terms');
+    }
+
+    /**
+     * Test getting a search timeline URL
+     *
+     * @since 2.0.0
+     *
+     * @covers ::getURL
+     *
+     * @return void
+     */
+    public function testGetURL()
+    {
+        $timeline = new \Twitter\Widgets\Embeds\Timeline\Search('');
+        $search_terms = 'foo bar';
+        $timeline->setSearchTerms($search_terms);
+        $this->assertEquals(\Twitter\Widgets\Embeds\Timeline\Search::BASE_URL . '?q=' . rawurlencode($search_terms), $timeline->getURL(), 'Failed to generate search URL');
+    }
+
+    /**
+     * Test creating a search timeline object from an associative parameter array
+     *
+     * @since 2.0.0
+     *
+     * @covers ::fromArray
+     *
+     * @return void
+     */
+    public function testFromArray()
+    {
+        $this->assertNull(\Twitter\Widgets\Embeds\Timeline\Search::fromArray(array()), 'Failed to reject empty array');
+        $this->assertNull(\Twitter\Widgets\Embeds\Timeline\Search::fromArray(array('foo'=>'bar')), 'Failed to reject array without an ID');
+        $this->assertNull(\Twitter\Widgets\Embeds\Timeline\Search::fromArray(array('widget_id'=>'')), 'Failed to reject widget ID of empty string');
+        $this->assertNull(\Twitter\Widgets\Embeds\Timeline\Search::fromArray(array('widget_id'=>42)), 'Failed to reject an int ID');
+
+        $width = 400;
+        $timeline = \Twitter\Widgets\Embeds\Timeline\Search::fromArray(array('widget_id'=>static::VALID_WIDGET_ID, 'width'=>$width));
+        $this->assertEquals(self::VALID_WIDGET_ID, self::getProperty($timeline, 'widget_id'), 'Failed to set widget ID from associative parameter array');
+        $this->assertEquals($width, self::getProperty($timeline, 'width'), 'Failed to set base parameter from associative array');
+    }
+
+    /**
+     * Test converting a search timeline object to a data-* style associative array
+     *
+     * @since 2.0.0
+     *
+     * @covers ::toArray
+     *
+     * @return void
+     */
+    public function testToArray()
+    {
+        $width = 400;
+        $timeline = new \Twitter\Widgets\Embeds\Timeline\Search(self::VALID_WIDGET_ID);
+        self::setProperty($timeline, 'width', $width);
+        $data = $timeline->toArray();
+
+        $this->assertArrayHasKey('widget-id', $data, 'Search timeline array does not include a widget ID');
+        $this->assertEquals(self::VALID_WIDGET_ID, $data['widget-id'], 'Widget ID in associative array does not match set object property');
+        $this->assertArrayHasKey('width', $data, 'Search timeline array does not include a set base timeline value');
+        $this->assertEquals($width, $data['width'], 'Search timeline array width value does not match set object property');
+    }
+
+    /**
+     * Test converting a search timeline object into oEmbed query parameters. Not supported
+     *
+     * @since 2.0.0
+     *
+     * @covers ::toOEmbedParameterArray
+     *
+     * @return void
+     */
+    public function testToOEmbedParameterArray()
+    {
+        $timeline = new \Twitter\Widgets\Embeds\Timeline\Search(self::VALID_WIDGET_ID);
+        self::setProperty($timeline, 'width', 400);
+        $this->assertEmpty($timeline->toOEmbedParameterArray(), 'Supplied oEmbed parameters for a timeline without oEmbed support');
+    }
+}


### PR DESCRIPTION
Build HTML markup for an embedded search timeline given a widget ID supplied via `twitter_search` shortcode or in the search timeline widget.

Optionally add search terms to match the configured embedded search widget to provide a meaningful link target and link text.