### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,9 @@
   "require": {
     "php": ">=5.4.0"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^4.8.36"
+  },
   "authors": [
     {
       "name": "Twitter",

--- a/tests/phpunit/Helpers/HTMLBuilder.php
+++ b/tests/phpunit/Helpers/HTMLBuilder.php
@@ -25,10 +25,12 @@ THE SOFTWARE.
 
 namespace Twitter\Tests\Helpers;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass \Twitter\Helpers\HTMLBuilder
  */
-final class HTMLBuilder extends \PHPUnit_Framework_TestCase
+final class HTMLBuilder extends TestCase
 {
     /**
      * Test proper escaping of a class name before it is inserted as a class attribute value

--- a/tests/phpunit/Helpers/TwitterURL.php
+++ b/tests/phpunit/Helpers/TwitterURL.php
@@ -25,10 +25,12 @@ THE SOFTWARE.
 
 namespace Twitter\Tests\Helpers;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass \Twitter\Helpers\TwitterURL
  */
-final class TwitterURL extends \PHPUnit_Framework_TestCase
+final class TwitterURL extends TestCase
 {
     /**
      * Test building a profile from a passed screen_name

--- a/tests/phpunit/Helpers/Validators/Hashtag.php
+++ b/tests/phpunit/Helpers/Validators/Hashtag.php
@@ -25,10 +25,12 @@ THE SOFTWARE.
 
 namespace Twitter\Tests\Helpers\Validators;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass \Twitter\Helpers\Validators\Hashtag
  */
-final class Hashtag extends \PHPUnit_Framework_TestCase
+final class Hashtag extends TestCase
 {
 
     /**

--- a/tests/phpunit/Helpers/Validators/ScreenName.php
+++ b/tests/phpunit/Helpers/Validators/ScreenName.php
@@ -25,10 +25,12 @@ THE SOFTWARE.
 
 namespace Twitter\Tests\Helpers\Validators;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass \Twitter\Helpers\Validators\ScreenName
  */
-final class ScreenName extends \PHPUnit_Framework_TestCase
+final class ScreenName extends TestCase
 {
     /**
      * Test trimming of an @ symbol before the screenname

--- a/tests/phpunit/Helpers/Validators/WebsiteTag.php
+++ b/tests/phpunit/Helpers/Validators/WebsiteTag.php
@@ -25,10 +25,12 @@ THE SOFTWARE.
 
 namespace Twitter\Tests\Helpers\Validators;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass \Twitter\Helpers\Validators\WebsiteTag
  */
-final class WebsiteTag extends \PHPUnit_Framework_TestCase
+final class WebsiteTag extends TestCase
 {
 	/**
 	 * Test validity of a website tag
@@ -87,7 +89,7 @@ final class WebsiteTag extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since 2.0.0
 	 *
-	 * @return array website tag value, 
+	 * @return array website tag value,
 	 */
 	public static function websiteTagProvider()
 	{

--- a/tests/phpunit/TestWithPrivateAccess.php
+++ b/tests/phpunit/TestWithPrivateAccess.php
@@ -25,12 +25,14 @@ THE SOFTWARE.
 
 namespace Twitter\Tests;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Create reflection wrappers for private and protected access
  *
  * @since 1.0.0
  */
-abstract class TestWithPrivateAccess extends \PHPUnit_Framework_TestCase
+abstract class TestWithPrivateAccess extends TestCase
 {
     /**
      * Get a private or protected property

--- a/tests/phpunit/Widgets/Language.php
+++ b/tests/phpunit/Widgets/Language.php
@@ -25,10 +25,12 @@ THE SOFTWARE.
 
 namespace Twitter\Tests\Widgets;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass \Twitter\Widgets\Language
  */
-final class Language extends \PHPUnit_Framework_TestCase
+final class Language extends TestCase
 {
 
     /**
@@ -55,7 +57,7 @@ final class Language extends \PHPUnit_Framework_TestCase
             $this->assertFalse(\Twitter\Widgets\Language::isSupportedLanguage($language_code), $message);
         }
     }
-    
+
     /**
      * Test language codes
      *

--- a/tests/phpunit/WordPress/Shortcodes/Embeds/Tweet/Video.php
+++ b/tests/phpunit/WordPress/Shortcodes/Embeds/Tweet/Video.php
@@ -25,11 +25,13 @@ THE SOFTWARE.
 
 namespace Twitter\Tests\WordPress\Shortcodes\Embeds\Tweet;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group shortcode
  * @coversDefaultClass \Twitter\WordPress\Shortcodes\Embeds\Tweet\Video
  */
-final class Video extends \PHPUnit_Framework_TestCase
+final class Video extends TestCase
 {
 
     /**


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to set PHPUnit minimum version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.