### PR TITLE
Update minimum version to 4.7 and add support for 4.8 and 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,20 +25,12 @@ php:
 # WordPress comes from the Git mirror, where 'master' mirrors svn 'trunk' and
 # x.y mirrors the latest from the x.y branch
 env:
+  # WordPress 4.9
+  - WP_VERSION=4.9
+  # WordPress 4.8
+  - WP_VERSION=4.8
   # WordPress 4.7
   - WP_VERSION=4.7
-  # WordPress 4.6
-  - WP_VERSION=4.6
-  # WordPress 4.5
-  - WP_VERSION=4.5
-  # WordPress 4.4
-  - WP_VERSION=4.4
-  # WordPress 4.3
-  - WP_VERSION=4.3
-  # WordPress 4.2
-  - WP_VERSION=4.2
-  # WordPress 4.1
-  - WP_VERSION=4.1
 
 matrix:
   fast_finish: true

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Plugin Name ===
 Contributors: Twitter, niallkennedy
 Tags: twitter, embedded tweet, embedded timeline, twitter profile, twitter list, twitter moment, twitter video, twitter grid, vine, periscope, twitter cards, tweet button, follow button, twitter analytics, twitter ads
-Requires at least: 4.1
-Tested up to: 4.7
+Requires at least: 4.7
+Tested up to: 4.9
 Stable tag: 2.0.1
 License: MIT
 License URI: https://opensource.org/licenses/MIT


### PR DESCRIPTION
Adding support for WordPress 4.8 and 4.9 in Travis test coverage and in the readme to let users know what we support.

Also removing versions of WordPress that are more than 1 year old.