### PR TITLE
Add support for WordPress 5.1 and update version to 2.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ php:
 # WordPress comes from the Git mirror, where 'master' mirrors svn 'trunk' and
 # x.y mirrors the latest from the x.y branch
 env:
+  # WordPress 5.1
+  - WP_VERSION=5.1
   # WordPress 5.0
   - WP_VERSION=5.0
   # WordPress 4.9

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Twitter plugin for WordPress optimizes your website for a Twitter audience t
 
 The Twitter plugin for WordPress requires PHP 5.4 or greater to take advantage of [traits](http://php.net/manual/language.oop5.traits.php), [late static bindings](http://php.net/manual/language.oop5.late-static-bindings.php) for extensibility, [namespaces](http://php.net/manual/language.namespaces.rationale.php), and Twitter libraries. Embedded Tweets require a server capable of communicating with Twitter's servers over TLS/SSL; the [cURL library](http://php.net/manual/book.curl.php) typically works best.
 
-Current version: `2.0.3`
+Current version: `2.0.4`
 
 [![Build Status](https://travis-ci.org/twitter/wordpress.svg)](https://travis-ci.org/twitter/wordpress)
 
@@ -18,8 +18,6 @@ Features built on top of oEmbed APIs omit JavaScript from the oEmbed response, a
 
 Add an [embedded Tweet](https://github.com/twitter/wordpress/wiki/Embedded-Tweet) to your site by URL or by using the `tweet` [shortcode macro](http://codex.wordpress.org/Shortcode). Shortcode syntax is compatible with Jetpack, allowing flexible migration for WordPress.com or Jetpack sites.
 
-Add a Twitter embedded video widget to your site by using the `twitter_video` shortcode macro.
-
 Customize an embedded Tweet color scheme to match your site's color palette. Choose a theme type, link color, and border color in the WordPress administrative interface.
 
 ### Twitter profile
@@ -30,15 +28,9 @@ Add an [embedded profile timeline](https://github.com/twitter/wordpress/wiki/Emb
 
 Add an [embedded list timeline](https://github.com/twitter/wordpress/wiki/Embedded-List-Timeline) to your site by URL, using the `[twitter_list]` shortcode macro, or adding a widget to your theme's widget area.
 
-### Twitter search
-
-Add an [embedded search timeline](https://github.com/twitter/wordpress/wiki/Embedded-Search-Timeline) to your site using the `[twitter_list]` shortcode macro or adding a widget to your theme's widget area.
-
 ### Collection
 
 Display a [Twitter collection](https://github.com/twitter/wordpress/wiki/Embedded-Collection-Timeline) by URL, using the `twitter_collection` shortcode macro, or adding widget to a theme's widget area.
-
-Add a Twitter collection with a grid template display to an article by URL or by using the `twitter_grid` shortcode macro.
 
 ### Embedded Moment
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Plugin Name ===
 Contributors: Twitter, niallkennedy, sobkowicz
-Tags: twitter, embedded tweet, embedded timeline, twitter profile, twitter list, twitter moment, twitter video, twitter grid, periscope, twitter cards, tweet button, follow button, twitter analytics, twitter ads
+Tags: twitter, embedded tweet, embedded timeline, twitter profile, twitter list, twitter moment, twitter video, periscope, twitter cards, tweet button, follow button, twitter analytics, twitter ads
 Requires at least: 4.7
-Tested up to: 5.0
-Stable tag: 2.0.3
+Tested up to: 5.1
+Stable tag: 2.0.4
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -19,10 +19,8 @@ Requires PHP version 5.4 or greater.
 Embed Twitter content by pasting a URL, customizing a shortcode, or in a widget area.
 
 * [single Tweet](https://github.com/twitter/wordpress/wiki/Embedded-Tweet "single Tweet embed")
-* [single Tweet with video template](https://github.com/twitter/wordpress/wiki/Embedded-Video "single Tweet with video embed")
 * [profile timeline](https://github.com/twitter/wordpress/wiki/Embedded-Profile-Timeline "Twitter embedded profile timeline")
 * [list timeline](https://github.com/twitter/wordpress/wiki/Embedded-List-Timeline "Twitter embedded list timeline")
-* [search timeline](https://github.com/twitter/wordpress/wiki/Embedded-Search-Timeline "Twitter embedded search timeline")
 * [collection](https://github.com/twitter/wordpress/wiki/Embedded-Collection-Timeline "Twitter embedded collection")
 * [Moment](https://github.com/twitter/wordpress/wiki/Moments "Twitter embedded Moment")
 
@@ -71,6 +69,10 @@ Shortcode improvements for ajax-loaded posts. Remove photo, gallery, and product
 Display admin notice if current PHP version does not meet minimum requirements. Do not display Tweet button in auto-generated excerpt.
 
 == Changelog ==
+= 2.0.4 =
+* Add support for WordPress 5.1
+* Remove documentation on video widget, grid widget, and search timeline widget which have been deprecated.
+
 = 2.0.3 =
 * Add support for WordPress 5.0
 

--- a/src/Twitter/WordPress/PluginLoader.php
+++ b/src/Twitter/WordPress/PluginLoader.php
@@ -41,7 +41,7 @@ class PluginLoader
 	 *
 	 * @type string
 	 */
-	const VERSION = '2.0.3';
+	const VERSION = '2.0.4';
 
 	/**
 	 * Unique domain of the plugin's translated text

--- a/twitter.php
+++ b/twitter.php
@@ -24,13 +24,13 @@ THE SOFTWARE.
 */
 /**
  * @package twitter
- * @version 2.0.3
+ * @version 2.0.4
  */
 /*
 Plugin Name: Twitter
 Plugin URI:  https://wordpress.org/plugins/twitter/
 Description: Official Twitter plugin for WordPress. Embed Twitter content and grow your audience on Twitter. Requires PHP 5.4 or greater.
-Version:     2.0.3
+Version:     2.0.4
 Author:      Twitter
 Author URI:  https://dev.twitter.com/
 License:     MIT


### PR DESCRIPTION
• Adds testing & support for WordPress 5.1
• Removes documentation on deprecated video, grid, and search timeline widgets
• Bumps plugin version to 2.0.4