### PR TITLE
Fix Tweet conversation option and add support for Wordpress 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ php:
 # WordPress comes from the Git mirror, where 'master' mirrors svn 'trunk' and
 # x.y mirrors the latest from the x.y branch
 env:
+  # WordPress 5.2
+  - WP_VERSION=5.2
   # WordPress 5.1
   - WP_VERSION=5.1
   # WordPress 5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ php:
   - 7.0
   # aliased to a recent 5.6.x version
   - 5.6
-  # aliased to a recent 5.5.x version
-  - 5.5
-  # aliased to a recent 5.4.x version
-  - 5.4
 
 # WordPress comes from the Git mirror, where 'master' mirrors svn 'trunk' and
 # x.y mirrors the latest from the x.y branch

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Twitter plugin for WordPress optimizes your website for a Twitter audience through easy to use sharing buttons, embedded Tweets, embedded timelines, auto-generated markup indexed by Twitter, and Follow buttons to help grow your Twitter audience. All features are deeply integrated with WordPress APIs to make building your webpages and administrative features as easy as possible with the extensibility you expect from WordPress.
 
-The Twitter plugin for WordPress requires PHP 5.4 or greater to take advantage of [traits](http://php.net/manual/language.oop5.traits.php), [late static bindings](http://php.net/manual/language.oop5.late-static-bindings.php) for extensibility, [namespaces](http://php.net/manual/language.namespaces.rationale.php), and Twitter libraries. Embedded Tweets require a server capable of communicating with Twitter's servers over TLS/SSL; the [cURL library](http://php.net/manual/book.curl.php) typically works best.
+The Twitter plugin for WordPress requires PHP 5.6 or greater to take advantage of [traits](http://php.net/manual/language.oop5.traits.php), [late static bindings](http://php.net/manual/language.oop5.late-static-bindings.php) for extensibility, [namespaces](http://php.net/manual/language.namespaces.rationale.php), and Twitter libraries. Embedded Tweets require a server capable of communicating with Twitter's servers over TLS/SSL; the [cURL library](http://php.net/manual/book.curl.php) typically works best.
 
 Current version: `2.0.5`
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Twitter plugin for WordPress optimizes your website for a Twitter audience t
 
 The Twitter plugin for WordPress requires PHP 5.4 or greater to take advantage of [traits](http://php.net/manual/language.oop5.traits.php), [late static bindings](http://php.net/manual/language.oop5.late-static-bindings.php) for extensibility, [namespaces](http://php.net/manual/language.namespaces.rationale.php), and Twitter libraries. Embedded Tweets require a server capable of communicating with Twitter's servers over TLS/SSL; the [cURL library](http://php.net/manual/book.curl.php) typically works best.
 
-Current version: `2.0.4`
+Current version: `2.0.5`
 
 [![Build Status](https://travis-ci.org/twitter/wordpress.svg)](https://travis-ci.org/twitter/wordpress)
 

--- a/compatibility-notice.php
+++ b/compatibility-notice.php
@@ -38,7 +38,7 @@ class Twitter_CompatibilityNotice {
 	 *
 	 * @type string
 	 */
-	const MIN_PHP_VERSION = '5.4';
+	const MIN_PHP_VERSION = '5.6';
 
 	/**
 	 * Release dates of PHP versions greater than the WordPress minimum requirement and less than the plugin minimum requirement

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "keywords": ["twitter","wordpress","plugin"],
   "require": {
-    "php": ">=5.4.0"
+    "php": ">=5.6.0"
   },
   "authors": [
     {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,7 @@
   <testsuites>
     <!-- Default test suite to run all tests -->
     <testsuite>
-      <directory phpVersion="5.4.0" suffix=".php">tests/phpunit</directory>
+      <directory phpVersion="5.6.0" suffix=".php">tests/phpunit</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,7 @@ Display admin notice if current PHP version does not meet minimum requirements. 
 = 2.0.5 =
 * Add support for WordPress 5.2
 * Fix conversation option to properly set hide_thread oEmbed param
+
 = 2.0.4 =
 * Add support for WordPress 5.1
 * Remove documentation on video widget, grid widget, and search timeline widget which have been deprecated.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Twitter, niallkennedy, sobkowicz
 Tags: twitter, embedded tweet, embedded timeline, twitter profile, twitter list, twitter moment, twitter video, periscope, twitter cards, tweet button, follow button, twitter analytics, twitter ads
 Requires at least: 4.7
-Tested up to: 5.1
-Stable tag: 2.0.4
+Tested up to: 5.2
+Stable tag: 2.0.5
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -69,6 +69,9 @@ Shortcode improvements for ajax-loaded posts. Remove photo, gallery, and product
 Display admin notice if current PHP version does not meet minimum requirements. Do not display Tweet button in auto-generated excerpt.
 
 == Changelog ==
+= 2.0.5 =
+* Add support for WordPress 5.2
+* Fix conversation option to properly set hide_thread oEmbed param
 = 2.0.4 =
 * Add support for WordPress 5.1
 * Remove documentation on video widget, grid widget, and search timeline widget which have been deprecated.

--- a/readme.txt
+++ b/readme.txt
@@ -7,13 +7,13 @@ Stable tag: 2.0.5
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
-Official Twitter and Periscope plugin for WordPress. Embed content and grow your audience. Requires PHP 5.4 or greater.
+Official Twitter and Periscope plugin for WordPress. Embed content and grow your audience. Requires PHP 5.6 or greater.
 
 == Description ==
 
 Embed Twitter content, improve sharing on Twitter, convert your web audience into Twitter or Periscope subscribers, and easily track visits to your website from Twitter advertising.
 
-Requires PHP version 5.4 or greater.
+Requires PHP version 5.6 or greater.
 
 = Embed Twitter content =
 Embed Twitter content by pasting a URL, customizing a shortcode, or in a widget area.

--- a/src/Twitter/Widgets/Embeds/Tweet.php
+++ b/src/Twitter/Widgets/Embeds/Tweet.php
@@ -265,6 +265,7 @@ class Tweet extends \Twitter\Widgets\Embeds\Tweet\Base
         if (isset($options['cards']) && ( false === $options['cards'] || 'false' === $options['cards'] || 0 == $options['cards'] )) {
             $tweet->hideCards();
         }
+
         if (isset($options['conversation']) && ( false === $options['conversation'] || 'false' === $options['conversation'] || 0 == $options['conversation'] )) {
             $tweet->hideParentTweet();
         }
@@ -333,7 +334,7 @@ class Tweet extends \Twitter\Widgets\Embeds\Tweet\Base
             $oembed['hide_media'] = false;
         }
         if (false === $this->conversation) {
-            $oembed['hide_thread'] = false;
+            $oembed['hide_thread'] = true;
         }
         if (static::ALIGN_NONE !== $this->align) {
             $oembed['align'] = $this->align;

--- a/src/Twitter/WordPress/PluginLoader.php
+++ b/src/Twitter/WordPress/PluginLoader.php
@@ -41,7 +41,7 @@ class PluginLoader
 	 *
 	 * @type string
 	 */
-	const VERSION = '2.0.4';
+	const VERSION = '2.0.5';
 
 	/**
 	 * Unique domain of the plugin's translated text

--- a/tests/phpunit/Widgets/Embeds/Tweet.php
+++ b/tests/phpunit/Widgets/Embeds/Tweet.php
@@ -310,7 +310,7 @@ final class Tweet extends \Twitter\Tests\TestWithPrivateAccess
         $this->assertArrayHasKey('hide_media', $parameters, 'Cards override not returned');
         $this->assertFalse($parameters['hide_media'], 'Failed to return false bool for cards override');
         $this->assertArrayHasKey('hide_thread', $parameters, 'Parent Tweet override not returned');
-        $this->assertFalse($parameters['hide_thread'], 'Failed to return false bool for conversation override');
+        $this->assertTrue($parameters['hide_thread'], 'Failed to return true bool for conversation override');
         $this->assertArrayHasKey('align', $parameters, 'Align value not returned');
         $this->assertEquals(\Twitter\Widgets\Embeds\Tweet::ALIGN_LEFT, $parameters['align'], 'Align value not returned as expected');
         $this->assertArrayHasKey('theme', $parameters, 'Theme value not returned');

--- a/twitter.php
+++ b/twitter.php
@@ -29,7 +29,7 @@ THE SOFTWARE.
 /*
 Plugin Name: Twitter
 Plugin URI:  https://wordpress.org/plugins/twitter/
-Description: Official Twitter plugin for WordPress. Embed Twitter content and grow your audience on Twitter. Requires PHP 5.4 or greater.
+Description: Official Twitter plugin for WordPress. Embed Twitter content and grow your audience on Twitter. Requires PHP 5.6 or greater.
 Version:     2.0.5
 Author:      Twitter
 Author URI:  https://dev.twitter.com/
@@ -49,8 +49,8 @@ if ( ! function_exists( 'add_action' ) ) {
 	exit( 'Hi there! I am a WordPress plugin requiring functions included with WordPress. I am not meant to be addressed directly.' );
 }
 
-// plugin requires PHP 5.4 or greater
-if ( version_compare( PHP_VERSION, '5.4.0', '<' ) ) {
+// plugin requires PHP 5.6 or greater
+if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
 	if ( ! class_exists( 'Twitter_CompatibilityNotice' ) ) {
 		require_once( dirname( __FILE__ ) . '/compatibility-notice.php' );
 	}

--- a/twitter.php
+++ b/twitter.php
@@ -24,13 +24,13 @@ THE SOFTWARE.
 */
 /**
  * @package twitter
- * @version 2.0.4
+ * @version 2.0.5
  */
 /*
 Plugin Name: Twitter
 Plugin URI:  https://wordpress.org/plugins/twitter/
 Description: Official Twitter plugin for WordPress. Embed Twitter content and grow your audience on Twitter. Requires PHP 5.4 or greater.
-Version:     2.0.4
+Version:     2.0.5
 Author:      Twitter
 Author URI:  https://dev.twitter.com/
 License:     MIT


### PR DESCRIPTION
- Fixes bug with the conversation option not hiding the parent Tweet when set to false
- Adds support for Wordpress 5.2
- Updates plugin version to 2.0.5